### PR TITLE
refactor(frontend): CHAIN_ID is dynamic by current environment

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,4 @@
+# This file is loaded when "react-scripts start"
+
+# Blockchain Id where contract is deployed
+REACT_APP_CHAIN_ID=1337

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,4 @@
+# This file is loaded when "react-scripts build"
+
+# Blockchain Id where contract is deployed
+REACT_APP_CHAIN_ID=1337

--- a/frontend/.env.test
+++ b/frontend/.env.test
@@ -1,0 +1,4 @@
+# This file is loaded when "react-scripts test"
+
+# Blockchain Id where contract is deployed
+REACT_APP_CHAIN_ID=1337

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -1,0 +1,12 @@
+export const CHAIN_ID = process.env.REACT_APP_CHAIN_ID as string;
+
+// Logger for dev
+if (process.env.NODE_ENV === 'development') {
+  console.log('CHAIN_ID', CHAIN_ID);
+}
+
+// Early abort ?
+if (typeof CHAIN_ID === 'undefined' || CHAIN_ID === '') {
+  throw new Error('Missing required env var "CHAIN_ID" !');
+}
+

--- a/frontend/src/lib/contracts/Sisyphus.ts
+++ b/frontend/src/lib/contracts/Sisyphus.ts
@@ -1,9 +1,10 @@
 import SisyphusContractArtifact from '../../assets/contracts/Sisyphus.artifact';
 import SisyphusContractAddress from '../../assets/contracts/Sisyphus.address.json';
+import { CHAIN_ID } from '../../constants';
 // import { useContract, useProvider, useSigner } from "wagmi";
 
 // 1. Export Contract Artifacts + Address
-export const contractAddress = SisyphusContractAddress[1337];
+export const contractAddress = SisyphusContractAddress[(CHAIN_ID as keyof typeof SisyphusContractAddress)];
 export const contractABI = SisyphusContractArtifact.abi;
 
 // 2. Export helpers for using the contract in the app.


### PR DESCRIPTION
For now all envs share `1337` as CHAIN_ID, this will change when we decide which chains to use.

This "Env <-> CHAIN_ID" constraint is dictated by these files :
- `frontend/.env.development`
- `frontend/.env.test`
- `frontend/.env.production`

However you can overrides these env var by creating a new file.
For example for overriting `.env.development` you create `.env.development.local` with new vars.

More info [here](https://create-react-app.dev/docs/adding-custom-environment-variables/#adding-development-environment-variables-in-env) on how Create-React-App uses env vars.